### PR TITLE
Change Flags.toDWord

### DIFF
--- a/src/main/scala/vonsim/simulator/Computer.scala
+++ b/src/main/scala/vonsim/simulator/Computer.scala
@@ -74,7 +74,7 @@ class Flags(
     }
   }
   def toDWord() = {
-    DWord(IndexedSeq(c.toInt, s.toInt, z.toInt, o.toInt).toInt())
+    DWord(IndexedSeq(c.toInt, s.toInt, o.toInt, z.toInt).toInt())
   }
   def canEqual(a: Any) = a.isInstanceOf[Flags]
   override def equals(a: Any) = {


### PR DESCRIPTION
I've noticed that `PUSHF` saves the ALU flags incorrectly to memory. After looking through the code, I've discovered that `Flags.toDWord` emits `CSZO` and the constructor `Flags` accepts `CSOZ`.

Here is an example code that doesn't work in the current version and works with this fix

```asm
org 2000h
MOV AX, 0FFFFh
ADD AX, 2
PUSHF
POPF ; C should be 1

CMP AX, AX
PUSHF
POPF ; Z should be 1

MOV AX, 08001h
ADD AX, 08000h
PUSHF
POPF ; C and O should be 1

MOV AX, 0F000h
CMP AX, 0
PUSHF
POPF ; S should be 1

hlt
end
```