### PR TITLE
Fixed declarations of variables of negative numbers

### DIFF
--- a/src/main/scala/vonsim/assembly/Compiler.scala
+++ b/src/main/scala/vonsim/assembly/Compiler.scala
@@ -494,7 +494,7 @@ object Compiler {
                   case None => None
                   case Some(v) => {
                     if (ComputerWord.bytesFor(v) > 1) {
-                      Some(None)
+                      Some(None) // Ignore values that are too big
                     } else{
                       Some(Some(Word(v)))
                     }
@@ -508,6 +508,8 @@ object Compiler {
                   case Some(Some(v)) => Some(v)
                 })
   
+              // The only way these two lists can have different sizes is if
+              // there was a value that didn't fit in 8 bits
               if(wordValues.size != values.size) {
                 semanticError(x, language.dontFitIn8Bits)
               } else {
@@ -516,7 +518,7 @@ object Compiler {
                   WordDef(
                     x.label,
                     resolver.vardefLabelAddress(x.label),
-                    wordValues.asInstanceOf[List[Option[Word]]]
+                    wordValues
                   )
                 )
               }
@@ -527,7 +529,7 @@ object Compiler {
                   case None => None
                   case Some(v)  => {
                     if (ComputerWord.bytesFor(v) > 2) {
-                      Some(None)
+                      Some(None) // Ignore values that are too big
                     } else{
                       Some(Some(DWord(v)))
                     }
@@ -541,6 +543,8 @@ object Compiler {
                   case Some(Some(v)) => Some(v)
                 })
   
+              // The only way these two lists can have different sizes is if
+              // there was a value that didn't fit in 16 bits
               if(dwordValues.size != values.size) {
                 semanticError(x, language.dontFitIn16Bits)
               } else {

--- a/src/main/scala/vonsim/assembly/Compiler.scala
+++ b/src/main/scala/vonsim/assembly/Compiler.scala
@@ -493,7 +493,7 @@ object Compiler {
 //          println("Values in def: "+values)
           val optionValues = values.map(_ match {
             case None    => Some(None)
-            case Some(v) => ComputerWord.minimalWordFor(v).map(Some(_))
+            case Some(v) => ComputerWord.minimalWordFor(v, x.t).map(Some(_))
           })
 
 //          println(optionValues)

--- a/src/main/scala/vonsim/assembly/Compiler.scala
+++ b/src/main/scala/vonsim/assembly/Compiler.scala
@@ -479,7 +479,6 @@ object Compiler {
         if (!undefinedLabels.isEmpty) {
           semanticError(x, language.labelsUndefined(undefinedLabels))
         } else {
-          println(x.values)
           val values = x.values.map(_ match {
             case Right(e) => {
               Some(resolver.expression(e))

--- a/src/main/scala/vonsim/simulator/ComputerWord.scala
+++ b/src/main/scala/vonsim/simulator/ComputerWord.scala
@@ -1,7 +1,5 @@
 package vonsim.simulator
 
-import vonsim.assembly.lexer.{VarType, DW}
-
 import ComputerWord._
 
 object ComputerWord {

--- a/src/main/scala/vonsim/simulator/ComputerWord.scala
+++ b/src/main/scala/vonsim/simulator/ComputerWord.scala
@@ -1,16 +1,25 @@
 package vonsim.simulator
 
+import vonsim.assembly.lexer.{VarType, DW}
+
 import ComputerWord._
 
 object ComputerWord {
 
-  def minimalWordFor(x: Int) = {
+  def minimalWordFor(x: Int, t: VarType) = {
     bytesFor(x) match {
       case 2 => Option(DWord(x))
-      case 1 => Option(Word(x))
+      case 1 => {
+        if (x < 0 && t.isInstanceOf[DW]) {
+          // If it's negative and it's a DW, we need to use a DWord
+          // This will ensure that the sign is extended
+          Option(DWord(x))
+        } else {
+          Option(Word(x))
+        }
+      }
       case _ => None
     }
-
   }
 
   // Minimum number of bytes to encode a number

--- a/src/main/scala/vonsim/simulator/ComputerWord.scala
+++ b/src/main/scala/vonsim/simulator/ComputerWord.scala
@@ -6,22 +6,6 @@ import ComputerWord._
 
 object ComputerWord {
 
-  def minimalWordFor(x: Int, t: VarType) = {
-    bytesFor(x) match {
-      case 2 => Option(DWord(x))
-      case 1 => {
-        if (x < 0 && t.isInstanceOf[DW]) {
-          // If it's negative and it's a DW, we need to use a DWord
-          // This will ensure that the sign is extended
-          Option(DWord(x))
-        } else {
-          Option(Word(x))
-        }
-      }
-      case _ => None
-    }
-  }
-
   // Minimum number of bytes to encode a number
   def ca2range(bytes: Int) = {
     val h = (Math.pow(2, (bitsPerByte * bytes) - 1) - 1).toInt


### PR DESCRIPTION
When declaring, for example `DW -10`, it is saved in memory as `00F6h` instead of `FFF6h`. This PR fixes that

Here is an example code that doesn't work in the current version and works with this fix

```asm
org 1000h
var DW -10

org 2000h
hlt
end
```