### PR TITLE
Implemented TEST instruction

### DIFF
--- a/docs/.vitepress/vonsim.tmLanguage.json
+++ b/docs/.vitepress/vonsim.tmLanguage.json
@@ -9,7 +9,7 @@
     { "name": "support.function.asm.vonsim", "match": "(?i)\\b(org|end)\\b" },
     {
       "name": "entity.name.mnemonic.asm.vonsim",
-      "match": "(?i)\\b(pushf?|popf?|i?ret|cli|sti|nop|hlt|mov|ad[dc]|s[ub]b|cmp|and|x?or|neg|inc|dec|not|call|jn?[cosz]|jmp|in|out|int)\\b"
+      "match": "(?i)\\b(pushf?|popf?|i?ret|cli|sti|nop|hlt|mov|ad[dc]|s[ub]b|cmp|and|x?or|test|neg|inc|dec|not|call|jn?[cosz]|jmp|in|out|int)\\b"
     },
     { "name": "storage.modifier.asm.vonsim", "match": "(?i)\\b(byte|word|ptr|offset)\\b" },
     {

--- a/docs/en/changelog.md
+++ b/docs/en/changelog.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+### XXX
+
+The [`TEST`](./computer/instructions/test) instruction has been added.
+
 ### July 31, 2024
 
 The method for adding devices has been changed. Users no longer choose configurations but can select devices arbitrarily.

--- a/docs/en/computer/instructions/index.md
+++ b/docs/en/computer/instructions/index.md
@@ -29,12 +29,13 @@ Here is a list of all the instructions supported by the simulator. Each instruct
 
 ### Logical Instructions
 
-| Instruction                 | Description                                      | `CF` | `ZF` | `SF` | `IF` | `OF` |
-| :-------------------------- | :----------------------------------------------- | :--: | :--: | :--: | :--: | :--: |
-| [`AND dest, source`](./and) | Performs bitwise AND between _dest_ and _source_ |  0   |  X   |  X   |  --  |  0   |
-| [`OR dest, source`](./or)   | Performs bitwise OR between _dest_ and _source_  |  0   |  X   |  X   |  --  |  0   |
-| [`XOR dest, source`](./xor) | Performs bitwise XOR between _dest_ and _source_ |  0   |  X   |  X   |  --  |  0   |
-| [`NOT dest`](./not)         | Performs bitwise NOT on _dest_                   |  0   |  X   |  X   |  --  |  0   |
+| Instruction                   | Description                                                  | `CF` | `ZF` | `SF` | `IF` | `OF` |
+| :---------------------------- | :----------------------------------------------------------- | :--: | :--: | :--: | :--: | :--: |
+| [`AND dest, source`](./and)   | Performs bitwise AND between _dest_ and _source_             |  0   |  X   |  X   |  --  |  0   |
+| [`OR dest, source`](./or)     | Performs bitwise OR between _dest_ and _source_              |  0   |  X   |  X   |  --  |  0   |
+| [`XOR dest, source`](./xor)   | Performs bitwise XOR between _dest_ and _source_             |  0   |  X   |  X   |  --  |  0   |
+| [`TEST dest, fuente`](./test) | Performs bitwise AND between _dest_ and _source_, only flags |  0   |  X   |  X   |  --  |  0   |
+| [`NOT dest`](./not)           | Performs bitwise NOT on _dest_                               |  0   |  X   |  X   |  --  |  0   |
 
 ### Control Transfer Instructions
 

--- a/docs/en/computer/instructions/test.md
+++ b/docs/en/computer/instructions/test.md
@@ -1,18 +1,18 @@
-# CMP
+# TEST
 
-This instruction subtracts the source operand from the destination operand. Neither of the operands is modified.
+This instruction performs a bitwise AND operation between the destination operand and the source operand (destination AND source). Neither of the operands is modified.
 
 The [_flags_](../cpu#flags) are modified as follows:
 
-- If the subtraction produces a result that cannot fit in the destination operand, then `CF=1`. Otherwise, `CF=0`.
+- `CF=0`.
 - If the result is zero, then `ZF=1`. Otherwise, `ZF=0`.
 - If the most significant bit of the result is `1`, then `SF=1`. Otherwise, `SF=0`.
-- If subtracting a positive number from a negative number results in a negative number, or subtracting a negative number from a positive number results in a positive number, then `OF=1`. Otherwise, `OF=0`.
+- `OF=0`.
 
 ## Usage
 
 ```vonsim
-CMP dest, source
+TEST dest, source
 ```
 
 The valid combinations for _dest_ and _source_ are:
@@ -28,27 +28,27 @@ The valid combinations for _dest_ and _source_ are:
 ## Encoding
 
 - REGISTER to register  
-  `1010110w`, `00RRRrrr`
+  `1010001w`, `00RRRrrr`
 - Memory (direct) to register  
-  `1010110w`, `01000rrr`, _addr-low_, _addr-high_
+  `1010001w`, `01000rrr`, _addr-low_, _addr-high_
 - Memory (indirect) to register  
-  `1010110w`, `01010rrr`
+  `1010001w`, `01010rrr`
 - Memory (indirect with displacement) to register  
-  `1010110w`, `01100rrr`, _disp-low_, _disp-high_
+  `1010001w`, `01100rrr`, _disp-low_, _disp-high_
 - Immediate to register  
-  `1010110w`, `01001rrr`, _data-low_, _data-high_
+  `1010001w`, `01001rrr`, _data-low_, _data-high_
 - Register to memory (direct)  
-  `1010110w`, `11000rrr`, _addr-low_, _addr-high_
+  `1010001w`, `11000rrr`, _addr-low_, _addr-high_
 - Register to memory (indirect)  
-  `1010110w`, `11010rrr`
+  `1010001w`, `11010rrr`
 - Register to memory (indirect with displacement)  
-  `1010110w`, `11100rrr`, _disp-low_, _disp-high_
+  `1010001w`, `11100rrr`, _disp-low_, _disp-high_
 - Immediate to memory (direct)  
-  `1010110w`, `11001000`, _addr-low_, _addr-high_, _data-low_, _data-high_
+  `1010001w`, `11001000`, _addr-low_, _addr-high_, _data-low_, _data-high_
 - Immediate to memory (indirect)  
-  `1010110w`, `11011000`, _data-low_, _data-high_
+  `1010001w`, `11011000`, _data-low_, _data-high_
 - Immediate to memory (indirect with displacement)  
-  `1010110w`, `11101000`, _disp-low_, _disp-high_, _data-low_, _data-high_
+  `1010001w`, `11101000`, _disp-low_, _disp-high_, _data-low_, _data-high_
 
 Where `w` is the operand size bit. `w=0` indicates 8-bit operands, and `w=1` indicates 16-bit operands. When `w=0`, _data-high_ is omitted (the instruction length is one byte shorter).
 

--- a/docs/en/reference/encoding.md
+++ b/docs/en/reference/encoding.md
@@ -44,7 +44,8 @@ Throughout the encoding, the following abbreviations are used:
 |    `ADC`    | `100 0101 w` |
 |    `SUB`    | `100 0110 w` |
 |    `SBB`    | `100 0111 w` |
-|    `CMP`    | `100 1000 w` |
+|   `TEST`    | `101 0001 w` |
+|    `CMP`    | `101 0110 w` |
 
 These instructions receive two operands and support various addressing modes. This information is encoded in the `d` bit and the second byte of the instruction according to the following table:
 

--- a/docs/es/changelog.md
+++ b/docs/es/changelog.md
@@ -1,5 +1,9 @@
 # Notas de versión
 
+### XXX
+
+Se agregó la instrucción [`TEST`](./computer/instructions/test).
+
 ### 31 de julio de 2024
 
 Se cambió la forma de agregar dispositivos. El usuario ya no elige configuraciones sino que puede escoger los dispositivos arbritariamente.

--- a/docs/es/computer/instructions/cmp.md
+++ b/docs/es/computer/instructions/cmp.md
@@ -28,27 +28,27 @@ Las combinaciones válidas de _dest_, _fuente_ son:
 ## Codificación
 
 - REGISTRO a registro  
-  `1001000w`, `00RRRrrr`
+  `1010110w`, `00RRRrrr`
 - Memoria (directo) a registro  
-  `1001000w`, `01000rrr`, _dir-low_, _dir-high_
+  `1010110w`, `01000rrr`, _dir-low_, _dir-high_
 - Memoria (indirecto) a registro  
-  `1001000w`, `01010rrr`
+  `1010110w`, `01010rrr`
 - Memoria (indirecto con desplazamiento) a registro  
-  `1001000w`, `01100rrr`, _desp-low_, _desp-high_
+  `1010110w`, `01100rrr`, _desp-low_, _desp-high_
 - Inmediato a registro  
-  `1001000w`, `01001rrr`, _dato-low_, _dato-high_
+  `1010110w`, `01001rrr`, _dato-low_, _dato-high_
 - Registro a memoria (directo)  
-  `1001000w`, `11000rrr`, _dir-low_, _dir-high_
+  `1010110w`, `11000rrr`, _dir-low_, _dir-high_
 - Registro a memoria (indirecto)  
-  `1001000w`, `11010rrr`
+  `1010110w`, `11010rrr`
 - Registro a memoria (indirecto con desplazamiento)  
-  `1001000w`, `11100rrr`, _desp-low_, _desp-high_
+  `1010110w`, `11100rrr`, _desp-low_, _desp-high_
 - Inmediato a memoria (directo)  
-  `1001000w`, `11001000`, _dir-low_, _dir-high_, _dato-low_, _dato-high_
+  `1010110w`, `11001000`, _dir-low_, _dir-high_, _dato-low_, _dato-high_
 - Inmediato a memoria (indirecto)  
-  `1001000w`, `11011000`, _dato-low_, _dato-high_
+  `1010110w`, `11011000`, _dato-low_, _dato-high_
 - Inmediato a memoria (indirecto con desplazamiento)  
-  `1001000w`, `11101000`, _desp-low_, _desp-high_, _dato-low_, _dato-high_
+  `1010110w`, `11101000`, _desp-low_, _desp-high_, _dato-low_, _dato-high_
 
 Donde `w` es el bit de tamaño de los operandos. `w=0` indica operandos de 8 bits y `w=1` operandos de 16 bits. Cuando `w=0`, _dato-high_ es obviado (la longitud de la instrucción es de un byte menos).
 

--- a/docs/es/computer/instructions/index.md
+++ b/docs/es/computer/instructions/index.md
@@ -35,6 +35,7 @@ Aquí se listan todas las instrucciones que soporta el simulador. Cada instrucci
 | [`OR dest, fuente`](./or)   | Operación _dest_ OR _fuente_ bit a bit  |  0   |  X   |  X   |  --  |  0   |
 | [`XOR dest, fuente`](./xor) | Operación _dest_ XOR _fuente_ bit a bit |  0   |  X   |  X   |  --  |  0   |
 | [`NOT dest`](./not)         | Operación NOT _dest_ bit a bit          |  0   |  X   |  X   |  --  |  0   |
+| [`TEST dest, fuente`](./test) | Operación _dest_ AND _fuente_ bit a bit, solo flags    |  X   |  X   |  X   |  --  |  X   |
 
 ### Instrucciones de transferencia de control
 

--- a/docs/es/computer/instructions/index.md
+++ b/docs/es/computer/instructions/index.md
@@ -29,13 +29,13 @@ Aquí se listan todas las instrucciones que soporta el simulador. Cada instrucci
 
 ### Instrucciones lógicas
 
-| Instrucción                 | Comentario                              | `CF` | `ZF` | `SF` | `IF` | `OF` |
-| :-------------------------- | :-------------------------------------- | :--: | :--: | :--: | :--: | :--: |
-| [`AND dest, fuente`](./and) | Operación _dest_ AND _fuente_ bit a bit |  0   |  X   |  X   |  --  |  0   |
-| [`OR dest, fuente`](./or)   | Operación _dest_ OR _fuente_ bit a bit  |  0   |  X   |  X   |  --  |  0   |
-| [`XOR dest, fuente`](./xor) | Operación _dest_ XOR _fuente_ bit a bit |  0   |  X   |  X   |  --  |  0   |
-| [`NOT dest`](./not)         | Operación NOT _dest_ bit a bit          |  0   |  X   |  X   |  --  |  0   |
-| [`TEST dest, fuente`](./test) | Operación _dest_ AND _fuente_ bit a bit, solo flags    |  X   |  X   |  X   |  --  |  X   |
+| Instrucción                   | Comentario                                          | `CF` | `ZF` | `SF` | `IF` | `OF` |
+| :---------------------------- | :-------------------------------------------------- | :--: | :--: | :--: | :--: | :--: |
+| [`AND dest, fuente`](./and)   | Operación _dest_ AND _fuente_ bit a bit             |  0   |  X   |  X   |  --  |  0   |
+| [`OR dest, fuente`](./or)     | Operación _dest_ OR _fuente_ bit a bit              |  0   |  X   |  X   |  --  |  0   |
+| [`XOR dest, fuente`](./xor)   | Operación _dest_ XOR _fuente_ bit a bit             |  0   |  X   |  X   |  --  |  0   |
+| [`TEST dest, fuente`](./test) | Operación _dest_ AND _fuente_ bit a bit, solo flags |  0   |  X   |  X   |  --  |  0   |
+| [`NOT dest`](./not)           | Operación NOT _dest_ bit a bit                      |  0   |  X   |  X   |  --  |  0   |
 
 ### Instrucciones de transferencia de control
 

--- a/docs/es/computer/instructions/test.md
+++ b/docs/es/computer/instructions/test.md
@@ -28,27 +28,27 @@ Las combinaciones válidas de _dest_, _fuente_ son:
 ## Codificación
 
 - REGISTRO a registro
-  `1001001w`, `00RRRrrr`
+  `1010001w`, `00RRRrrr`
 - Memoria (directo) a registro
-  `1001001w`, `01000rrr`, _dir-low_, _dir-high_
+  `1010001w`, `01000rrr`, _dir-low_, _dir-high_
 - Memoria (indirecto) a registro
-  `1001001w`, `01010rrr`
+  `1010001w`, `01010rrr`
 - Memoria (indirecto con desplazamiento) a registro
-  `1001001w`, `01100rrr`, _desp-low_, _desp-high_
+  `1010001w`, `01100rrr`, _desp-low_, _desp-high_
 - Inmediato a registro
-  `1001001w`, `01001rrr`, _dato-low_, _dato-high_
+  `1010001w`, `01001rrr`, _dato-low_, _dato-high_
 - Registro a memoria (directo)
-  `1001001w`, `11000rrr`, _dir-low_, _dir-high_
+  `1010001w`, `11000rrr`, _dir-low_, _dir-high_
 - Registro a memoria (indirecto)
-  `1001001w`, `11010rrr`
+  `1010001w`, `11010rrr`
 - Registro a memoria (indirecto con desplazamiento)
-  `1001001w`, `11100rrr`, _desp-low_, _desp-high_
+  `1010001w`, `11100rrr`, _desp-low_, _desp-high_
 - Inmediato a memoria (directo)
-  `1001001w`, `11001000`, _dir-low_, _dir-high_, _dato-low_, _dato-high_
+  `1010001w`, `11001000`, _dir-low_, _dir-high_, _dato-low_, _dato-high_
 - Inmediato a memoria (indirecto)
-  `1001001w`, `11011000`, _dato-low_, _dato-high_
+  `1010001w`, `11011000`, _dato-low_, _dato-high_
 - Inmediato a memoria (indirecto con desplazamiento)
-  `1001001w`, `11101000`, _desp-low_, _desp-high_, _dato-low_, _dato-high_
+  `1010001w`, `11101000`, _desp-low_, _desp-high_, _dato-low_, _dato-high_
 
 Donde `w` es el bit de tamaño de los operandos. `w=0` indica operandos de 8 bits y `w=1` operandos de 16 bits. Cuando `w=0`, _dato-high_ es obviado (la longitud de la instrucción es de un byte menos).
 

--- a/docs/es/computer/instructions/test.md
+++ b/docs/es/computer/instructions/test.md
@@ -1,4 +1,4 @@
-        # TEST
+# TEST
 
 Esta instrucción reliza la operación lógica AND bit a bit entre el operando destino y el operando fuente (destino AND fuente). El resultado de la operación lógica no se guarda.
 

--- a/docs/es/computer/instructions/test.md
+++ b/docs/es/computer/instructions/test.md
@@ -1,0 +1,66 @@
+        # TEST
+
+Esta instrucción reliza la operación lógica AND bit a bit entre el operando destino y el operando fuente (destino AND fuente). El resultado de la operación lógica no se guarda.
+
+Los [_flags_](../cpu#flags) se modifican de la siguiente manera:
+
+- `CF=0`.
+- Si el resultado es cero, entonces `ZF=1`. De lo contrario, `ZF=0`.
+- Si el el bit más significativo del resultado es `1`, entonces `SF=1`. De lo contrario, `SF=0`.
+- `OF=0`.
+
+## Uso
+
+```vonsim
+TEST dest, fuente
+```
+
+Las combinaciones válidas de _dest_, _fuente_ son:
+
+- Registro, registro
+- Registro, dirección de memoria
+- Registro, inmediato
+- Dirección de memoria, registro
+- Dirección de memoria, inmediato
+
+(Ver [tipos de operandos](../assembly#operandos))
+
+## Codificación
+
+- REGISTRO a registro
+  `1001001w`, `00RRRrrr`
+- Memoria (directo) a registro
+  `1001001w`, `01000rrr`, _dir-low_, _dir-high_
+- Memoria (indirecto) a registro
+  `1001001w`, `01010rrr`
+- Memoria (indirecto con desplazamiento) a registro
+  `1001001w`, `01100rrr`, _desp-low_, _desp-high_
+- Inmediato a registro
+  `1001001w`, `01001rrr`, _dato-low_, _dato-high_
+- Registro a memoria (directo)
+  `1001001w`, `11000rrr`, _dir-low_, _dir-high_
+- Registro a memoria (indirecto)
+  `1001001w`, `11010rrr`
+- Registro a memoria (indirecto con desplazamiento)
+  `1001001w`, `11100rrr`, _desp-low_, _desp-high_
+- Inmediato a memoria (directo)
+  `1001001w`, `11001000`, _dir-low_, _dir-high_, _dato-low_, _dato-high_
+- Inmediato a memoria (indirecto)
+  `1001001w`, `11011000`, _dato-low_, _dato-high_
+- Inmediato a memoria (indirecto con desplazamiento)
+  `1001001w`, `11101000`, _desp-low_, _desp-high_, _dato-low_, _dato-high_
+
+Donde `w` es el bit de tamaño de los operandos. `w=0` indica operandos de 8 bits y `w=1` operandos de 16 bits. Cuando `w=0`, _dato-high_ es obviado (la longitud de la instrucción es de un byte menos).
+
+`rrr` o `RRR` codifica un registro según la siguiente tabla:
+
+| `rrr` | `w=0` | `w=1` |
+| :---: | :---: | :---: |
+| `000` | `AL`  | `AX`  |
+| `001` | `CL`  | `CX`  |
+| `010` | `DL`  | `DX`  |
+| `011` | `BL`  | `BX`  |
+| `100` | `AH`  | `SP`  |
+| `101` | `CH`  |  --   |
+| `110` | `DH`  |  --   |
+| `111` | `BH`  |  --   |

--- a/docs/es/reference/codification.md
+++ b/docs/es/reference/codification.md
@@ -42,8 +42,8 @@ A lo largo de la codificación se usan las siguientes abreviaturas:
 |    `ADC`    | `100 0101 w` |
 |    `SUB`    | `100 0110 w` |
 |    `SBB`    | `100 0111 w` |
-|    `CMP`    | `100 1000 w` |
-|    `TEST`   | `100 1001 w` |
+|   `TEST`    | `101 0001 w` |
+|    `CMP`    | `101 0110 w` |
 
 Estas instrucciones reciben dos operandos y soportan varios modos de direccionamiento. Esta información está codificada en el bit `d` y el segundo byte de la instrucción según la siguiente tabla:
 

--- a/docs/es/reference/codification.md
+++ b/docs/es/reference/codification.md
@@ -43,6 +43,7 @@ A lo largo de la codificación se usan las siguientes abreviaturas:
 |    `SUB`    | `100 0110 w` |
 |    `SBB`    | `100 0111 w` |
 |    `CMP`    | `100 1000 w` |
+|    `TEST`   | `100 1001 w` |
 
 Estas instrucciones reciben dos operandos y soportan varios modos de direccionamiento. Esta información está codificada en el bit `d` y el segundo byte de la instrucción según la siguiente tabla:
 

--- a/packages/assembler/src/statements/instructions/index.ts
+++ b/packages/assembler/src/statements/instructions/index.ts
@@ -38,6 +38,7 @@ export function createInstructionStatement(
     case "AND":
     case "OR":
     case "XOR":
+    case "TEST":
       return new BinaryInstruction(token.type, operands, label, position);
     case "NEG":
     case "INC":

--- a/packages/assembler/src/statements/instructions/types/binary.ts
+++ b/packages/assembler/src/statements/instructions/types/binary.ts
@@ -10,7 +10,17 @@ import { registerToBits } from "../encoding";
 import type { Operand } from "../operands";
 import { InstructionStatement } from "../statement";
 
-type BinaryInstructionName = "MOV" | "ADD" | "ADC" | "SUB" | "SBB" | "CMP" | "AND" | "OR" | "XOR" | "TEST";
+type BinaryInstructionName =
+  | "MOV"
+  | "ADD"
+  | "ADC"
+  | "SUB"
+  | "SBB"
+  | "CMP"
+  | "AND"
+  | "OR"
+  | "XOR"
+  | "TEST";
 
 type InitialMemoryAccess = { mode: "direct"; address: NumberExpression } | { mode: "indirect" };
 
@@ -127,8 +137,8 @@ export class BinaryInstruction extends InstructionStatement {
       ADC: 0b100_0101_0,
       SUB: 0b100_0110_0,
       SBB: 0b100_0111_0,
-      CMP: 0b100_1000_0,
-      TEST: 0b100_1001_0,
+      CMP: 0b101_0110_0,
+      TEST: 0b101_0001_0,
     };
     bytes[0] = opcodes[this.instruction];
 

--- a/packages/assembler/src/statements/instructions/types/binary.ts
+++ b/packages/assembler/src/statements/instructions/types/binary.ts
@@ -10,7 +10,7 @@ import { registerToBits } from "../encoding";
 import type { Operand } from "../operands";
 import { InstructionStatement } from "../statement";
 
-type BinaryInstructionName = "MOV" | "ADD" | "ADC" | "SUB" | "SBB" | "CMP" | "AND" | "OR" | "XOR";
+type BinaryInstructionName = "MOV" | "ADD" | "ADC" | "SUB" | "SBB" | "CMP" | "AND" | "OR" | "XOR" | "TEST";
 
 type InitialMemoryAccess = { mode: "direct"; address: NumberExpression } | { mode: "indirect" };
 
@@ -46,6 +46,7 @@ type Operation =
  * - {@link https://vonsim.github.io/en/computer/instructions/and | AND}
  * - {@link https://vonsim.github.io/en/computer/instructions/or | OR}
  * - {@link https://vonsim.github.io/en/computer/instructions/xor | XOR}
+ * - {@link https://vonsim.github.io/en/computer/instructions/test | TEST}
  *
  * These instructions need two operands:
  * - `out`: the destination operand (left operand)
@@ -127,6 +128,7 @@ export class BinaryInstruction extends InstructionStatement {
       SUB: 0b100_0110_0,
       SBB: 0b100_0111_0,
       CMP: 0b100_1000_0,
+      TEST: 0b100_1001_0,
     };
     bytes[0] = opcodes[this.instruction];
 

--- a/packages/assembler/src/types.ts
+++ b/packages/assembler/src/types.ts
@@ -47,6 +47,7 @@ export const INSTRUCTIONS = [
   "AND",
   "OR",
   "XOR",
+  "TEST",
   // Control transfer
   "CALL",
   "JMP",

--- a/packages/simulator/src/cpu/instructions/alu-binary.ts
+++ b/packages/simulator/src/cpu/instructions/alu-binary.ts
@@ -15,6 +15,7 @@ import type { PartialFlags } from "../types";
  * - {@link https://vonsim.github.io/en/computer/instructions/and | AND}
  * - {@link https://vonsim.github.io/en/computer/instructions/or | OR}
  * - {@link https://vonsim.github.io/en/computer/instructions/xor | XOR}
+ * - {@link https://vonsim.github.io/en/computer/instructions/test | TEST}
  *
  * @see {@link Instruction}
  *
@@ -22,7 +23,7 @@ import type { PartialFlags } from "../types";
  * This class is: IMMUTABLE
  */
 export class ALUBinaryInstruction extends Instruction<
-  "AND" | "OR" | "XOR" | "ADD" | "ADC" | "SUB" | "SBB" | "CMP"
+  "AND" | "OR" | "XOR" | "ADD" | "ADC" | "SUB" | "SBB" | "CMP" | "TEST"
 > {
   get operation() {
     return this.statement.operation;
@@ -150,11 +151,12 @@ export class ALUBinaryInstruction extends Instruction<
     switch (this.name) {
       case "AND":
       case "OR":
-      case "XOR": {
+      case "XOR":
+      case "TEST": {
         // When performing bitwise operations, we use signed numbers
         // because we want to preserve the sign bit in JavaScript.
         const signed =
-          this.name === "AND"
+          (this.name === "AND" || this.name === "TEST")
             ? left.signed & right.signed
             : this.name === "OR"
               ? left.signed | right.signed
@@ -217,7 +219,7 @@ export class ALUBinaryInstruction extends Instruction<
 
     yield* computer.cpu.aluExecute(this.name === "CMP" ? "SUB" : this.name, result, flags);
 
-    if (this.name === "CMP") return true; // No writeback
+    if (this.name === "CMP" || this.name === "TEST") return true; // No writeback
 
     yield { type: "cpu:cycle.update", phase: "writeback" };
 

--- a/packages/simulator/src/cpu/instructions/index.ts
+++ b/packages/simulator/src/cpu/instructions/index.ts
@@ -42,8 +42,9 @@ export function statementToInstruction(statement: InstructionStatement): Instruc
     case "SUB":
     case "SBB":
     case "CMP":
+    case "TEST":
       return new ALUBinaryInstruction(
-        statement as PickInstruction<"AND" | "OR" | "XOR" | "ADD" | "ADC" | "SUB" | "SBB" | "CMP">,
+        statement as PickInstruction<"AND" | "OR" | "XOR" | "ADD" | "ADC" | "SUB" | "SBB" | "CMP"| "TEST">,
       );
     case "NOT":
     case "NEG":


### PR DESCRIPTION
In this pull request I have added the TEST instruction.

The TEST instruction performs a logical "AND" which sets the flag but does not affect the destination. 

This is used to determine the value of bits in a byte, although the AND instruction can be used, having this specific instruction can help to know the intention of the programmer.  The test istruction has a different semantic meaning.

This is the same that happens between the SUB and CMP instruction.